### PR TITLE
Allow local debugging with support repo tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# IntelliJ users
+.idea
+

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ jspm_packages
 # IntelliJ users
 .idea
 
+# Don't toy with settings in VS Code
+.vscode/settings.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Attach to Docker",
+            "type": "node",
+            "request": "attach",
+            "port": 5858,
+            // localhost works on OSes where virtualization is natively supported
+            // On Windows 7, see https://gamestop.atlassian.net/wiki/x/twFBAg for configuration instructions
+            // Hint: you'll need to replace localhost with the IP address of the running VM to enable local debugging
+            "address": "localhost",
+            "restart": false,
+            "sourceMaps": false,
+            "outDir": null,
+            "localRoot": "${workspaceRoot}/",
+            "remoteRoot": "/var/task/"
+        },
+        {
+            "name": "Attach to Process",
+            "type": "node",
+            "request": "attach",
+            "processId": "${command.PickProcess}",
+            "port": 5858,
+            "sourceMaps": false,
+            "outDir": null
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-// Place your settings in this file to overwrite default and user settings.
-{
-    "files.eol": "\n",
-    "files.trimTrailingWhitespace": true,
-    "editor.tabSize": 2
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "files.eol": "\n",
+    "files.trimTrailingWhitespace": true,
+    "editor.tabSize": 2
+}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ To deploy Odin to your AWS environment simply use your favorite CI/CD tools (thi
 
 Currently only stack age is configurable outside of the node code - steps 1 and 2 are written into the application logic in [stacks/check.js](https://github.com/manwaring/odin/blob/master/stacks/check.js).  To modify the frequency with which Odin checks for stale stacks as well as the length of time used to determine staleness you can update the schedule and input parameters defined for the CheckStacks function in [serverless.yml](https://github.com/manwaring/odin/blob/master/serverless.yml).  To modify the rules used for stage tags and stack status you will need to modify the helper methods in [stacks/check.js](https://github.com/manwaring/odin/blob/master/stacks/check.js).
 
+# Local Debugging
+
+The '.vscode' folder contains settings for making local debugging via [VS Code](https://code.visualstudio.com/) a bit easier, especially if you don't have a Node environment already running or you are running a different version of Node.
+
+See [this README.md](https://github.com/pariveda-serverless/support/blob/master/nodejs/4.3.2/local/README.md) for more on how you can debug Odin with this tool.
+
 # Limitations
 Unlike his Norse namesake Odin is unable to practice magic and cannot remove stacks that aren't self-removing.
 


### PR DESCRIPTION
Look at me, @manwaring - getting some real-Odin under my belt. Now I can debug it locally using the tools at https://github.com/pariveda-serverless/support/tree/fix-local-docker-debug/nodejs/4.3.2/local 